### PR TITLE
add .checked_87bf1 rule

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -386,6 +386,9 @@
 .container__87bf1 {
 	background-color: rgba(var(--gruv-dark-bg2)) !important
 }
+.checked__87bf1 {
+    background-color: rgba(var(--gruv-dark-yellow-dark)) !important;
+}
 
 /* "Share your screen" button */
 .theme-dark [class*="experimentButton_"][class*="buttonColor_"][class*="buttonActive_"] {


### PR DESCRIPTION
added new rule for setting the background color of checked check boxes, some check boxes like in the Vencord "Plugins" tab would have no color indicator of being checked

without rule:

![image](https://github.com/user-attachments/assets/b0f181fe-c324-422f-8f1b-0b4cb7e4200a)

with new rule:

![image](https://github.com/user-attachments/assets/8b5f2bca-81a1-4beb-8854-96ec1f7705cc)