### PR TITLE
add background tweaks

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -540,6 +540,10 @@
     background-color: rgba(var(--gruv-dark-bg1));
 }
 
+.overlay_c0bea0 {
+    background-color: rgba(var(--gruv-dark-bg));
+}
+
 /* ==== Nuked elements ==== */
 
 /* Top to bottom */

--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -532,6 +532,14 @@
 	background-color: rgba(var(--gruv-dark-bg))
 }
 
+/* Background tweaks to fix Discord's inconsistent syling */
+
+.connection_c7f964,
+.connectContainer_c7f964,
+.appDetailsContainer__50a54 {
+    background-color: rgba(var(--gruv-dark-bg1));
+}
+
 /* ==== Nuked elements ==== */
 
 /* Top to bottom */


### PR DESCRIPTION
discord has inconsistent styling on some elements

before tweaks:

<img src="https://github.com/user-attachments/assets/755dabd3-976a-4a39-a2f7-ec77701e93c0" height="500px">

<img src="https://github.com/user-attachments/assets/8ba25167-390f-4a35-961b-da6e7dd73815" height="500px">

<img src="https://github.com/user-attachments/assets/b64595b2-c038-4488-97c7-1bbcc2d91d66" height="500px">

after tweaks:

<img src="https://github.com/user-attachments/assets/8cc9b450-9484-43db-8ed5-a069234daab3" height="500px">

<img src="https://github.com/user-attachments/assets/89ad23e7-065d-4aea-8622-238171cdfe66" height="500px">

<img src="https://github.com/user-attachments/assets/29aa036a-b539-4da3-8177-f82348b3e6ae" height="500px">
