### PR TITLE
fix blank gif on hover

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -547,6 +547,11 @@
     background-color: rgba(var(--gruv-dark-bg));
 }
 
+/* Hovering over gifs would cause them to go blank  */
+.result__2dc39:after {
+    content: normal;
+}
+
 /* ==== Nuked elements ==== */
 
 /* Top to bottom */


### PR DESCRIPTION
when hovering over a gif it would go blank

before:

https://github.com/user-attachments/assets/77929264-ebfd-470d-ad57-a639279ebca8

after:

https://github.com/user-attachments/assets/23242884-b8d4-4915-be25-fabc5a056769