### PR TITLE
fix nitro profile overlay_c0bea0 background color

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -362,6 +362,8 @@
 	--redesign-button-positive-text: rgba(var(--gruv-dark-text-hard));
 	--redesign-button-overlay-alpha-text: rgba(var(--gruv-dark-text-hard));
 	--redesign-button-overlay-alpha-background: rgba(0, 0, 0, 0.3);
+
+	--user-profile-overlay-background: rgba(var(--gruv-dark-bg));
 }
 
 /* Invite button inside call box */
@@ -548,10 +550,6 @@
 .appDetailsContainer__50a54 {
     background-color: rgba(var(--gruv-dark-bg-soft));
 	border: 1px solid rgba(var(--gruv-dark-border-default))
-}
-
-.overlay_c0bea0 {
-    background-color: rgba(var(--gruv-dark-bg));
 }
 
 /* Hovering over gifs would cause them to go blank  */


### PR DESCRIPTION
pr #2 changed the background color of all profile overlays including custom nitro colored ones, this pr fixes that so only non custom colored ones will have the correct background

before:

![image](https://github.com/user-attachments/assets/aaf210fe-289f-4553-9ea1-8a939e36c340)

after:

![image](https://github.com/user-attachments/assets/edf596dd-bffb-4fec-98c8-4d9012a3b6ba)
