### PR TITLE
adjust profile overlay background color to hard

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -363,7 +363,7 @@
 	--redesign-button-overlay-alpha-text: rgba(var(--gruv-dark-text-hard));
 	--redesign-button-overlay-alpha-background: rgba(0, 0, 0, 0.3);
 
-	--user-profile-overlay-background: rgba(var(--gruv-dark-bg));
+	--user-profile-overlay-background: rgba(var(--gruv-dark-bg-hard));
 }
 
 /* Invite button inside call box */


### PR DESCRIPTION
pr #2 set the profile overlay background color to be the normal bg, it should be the hard version

![Screenshot_20250426_201520](https://github.com/user-attachments/assets/3b36c979-964d-4661-92dd-7f867e013972)

![image](https://github.com/user-attachments/assets/560d27a2-dd02-4196-8adc-ae0040d50123)

also wondering if the activity background color should be the hard version or if this pr should be thrown out if it all should be the normal bg