### PR TITLE
fix my account profile overlay

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -552,6 +552,15 @@
 	border: 1px solid rgba(var(--gruv-dark-border-default))
 }
 
+.background__1fed1,
+.background__1fed1 > .fieldList__1fed1 {
+    background-color: var(--user-profile-overlay-background);
+}
+
+.badgeList__1fed1 {
+    background-color: transparent;
+}
+
 /* Hovering over gifs would cause them to go blank  */
 .result__2dc39:after {
     content: normal;


### PR DESCRIPTION
the most minor of color tweaks

# before

![image](https://github.com/user-attachments/assets/c876ccf2-65d3-41cd-9658-94e351b9744d)

# after

![image](https://github.com/user-attachments/assets/b7abc051-7d5f-47c9-9d58-c42f817cab74)

# compare with

![image](https://github.com/user-attachments/assets/3b8aed4d-edf1-4cf3-8103-8515aa3644e0)