### PR TITLE
fix wrong colors for small status masks

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -473,6 +473,22 @@
   }
 }
 
+rect[fill="#43a25a"] {
+    fill: var(--status-online);
+}
+
+rect[fill="#ca9654"] {
+    fill: var(--status-idle);
+}
+
+rect[fill="#d83a42"] {
+    fill: var(--status-dnd);
+}
+
+rect[fill="#82838b"] {
+    fill: var(--status-offline);
+}
+
 /* Screenshare icon */
 .icon_c9d15c > path {
 	fill: rgba(var(--gruv-dark-accent))


### PR DESCRIPTION
# before

![image](https://github.com/user-attachments/assets/cafefc19-31c2-43a0-9055-581ab5329aa5)
![image](https://github.com/user-attachments/assets/c4d5fdd5-e086-484f-a662-98950227d3f9)
![image](https://github.com/user-attachments/assets/30fee460-3395-4e41-9374-a1b63ade91a3)

# after

![image](https://github.com/user-attachments/assets/194c8946-66d7-461d-b4bf-636e7c36b64d)
![image](https://github.com/user-attachments/assets/ceba3f0b-11a4-40a1-93d6-585b4ca1dd31)
![image](https://github.com/user-attachments/assets/e977e986-5966-4168-8ed7-e04b7f9e580a)
![image](https://github.com/user-attachments/assets/56a20e19-cde2-407e-b12c-d63b44080045)

---

the attribute colors are hardcoded because i couldnt go by the mask attribute since it changed between different users statuses even though they are the same mask