### PR TITLE
fix small status color of online groups

### DIFF
--- a/gruvbox-dark.theme.css
+++ b/gruvbox-dark.theme.css
@@ -489,6 +489,10 @@ rect[fill="#82838b"] {
     fill: var(--status-offline);
 }
 
+div.status_a423bd {
+    background-color: var(--status-online) !important;
+}
+
 /* Screenshare icon */
 .icon_c9d15c > path {
 	fill: rgba(var(--gruv-dark-accent))


### PR DESCRIPTION
# before

![image](https://github.com/user-attachments/assets/0769defe-5c1a-4db0-bdce-5939ac7179e9)

# after 

![image](https://github.com/user-attachments/assets/ae440eb1-d949-4ed6-b782-ff7ff24b2bde)

---

sorry i didnt realize this in my previous pr